### PR TITLE
Fix composer require problem

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,10 @@
 
     "require": {
         "php": ">=7.0",
-        "laravel/laravel": "5.*"
-    },
-
+        "illuminate/contracts": "5.*",
+        "illuminate/support": "5.*",
+        "illuminate/view": "5.*"
+	},
     "require-dev": {
         "phpunit/phpunit": "~6.0",
         "mockery/mockery": "0.9.*",


### PR DESCRIPTION
As title.
The install/require/update action will get an error message when you use "laravel/laravel" in the require block. 
[Error Log 1 (Update L5.6 -> L5.7)](https://pastebin.com/93c2R2wH)
[Error Log 2 (New L5.7 project run `composer require yish/generators`)](https://pastebin.com/bfkR70mp)
So, just change it back, and it works.